### PR TITLE
Javadoc fixed

### DIFF
--- a/examples/showcase/src/main/java/org/richfaces/demo/push/PushCdiBean.java
+++ b/examples/showcase/src/main/java/org/richfaces/demo/push/PushCdiBean.java
@@ -45,8 +45,6 @@ public class PushCdiBean {
 
     /**
      * Sends message.
-     *
-     * @param message to send
      */
     public void sendMessage() {
         pushEvent.fire(message);


### PR DESCRIPTION
there is a warning about wrong Javadoc during build

```
[WARNING] .../src/main/java/org/richfaces/demo/push/PushCdiBean.java:51: warning - @param argument "message" is not a parameter name.
```
