### PR TITLE
maven-resources-plugin upgraded to 2.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
         <version.surefire.plugin>2.11</version.surefire.plugin>
         
         <!-- Plugin Management: versions -->
+        <version.resources.plugin>2.6</version.resources.plugin>
         <version.xml.plugin>1.0</version.xml.plugin>
         <version.javacc.plugin>2.4.1</version.javacc.plugin>
         <version.invoker.plugin>1.3</version.invoker.plugin>
@@ -217,7 +218,10 @@
                 </plugin>
 
 
-
+                <plugin>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>${version.resources.plugin}</version>
+                </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>xml-maven-plugin</artifactId>


### PR DESCRIPTION
maven-resources-plugin upgraded in order to reduce unnecessary debug information in project build

```
[INFO] --- maven-resources-plugin:2.5:resources (default-resources) @ project ---
[debug] execute contextualize
```

See http://jira.codehaus.org/browse/MRESOURCES-140 for more information.
