### PR TITLE
RF-12995: demo for r:outputPanel can not be parsed - fixed

### DIFF
--- a/examples/showcase/src/main/webapp/richfaces/outputPanel/samples/compositeMessages-sample.xhtml
+++ b/examples/showcase/src/main/webapp/richfaces/outputPanel/samples/compositeMessages-sample.xhtml
@@ -23,7 +23,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <ui:composition xmlns="http://www.w3.org/1999/xhtml" xmlns:h="http://java.sun.com/jsf/html"
     xmlns:f="http://java.sun.com/jsf/core" xmlns:ui="http://java.sun.com/jsf/facelets" 
-    xmlns:r="http://richfaces.org/rich" xmlns:r="http://java.sun.com/jsf/composite/org.richfaces.showcase">
+    xmlns:r="http://richfaces.org/rich">
     <h:form>
         <r:panel id="panel">
             <f:facet name="header">


### PR DESCRIPTION
- there was multiple declaration of r namespace, the incorrect one was deleted
