### PR TITLE
RF-12593: fix hangling of complex types by RenderKitUtils#toScriptArgs

### DIFF
--- a/framework/src/main/java/org/richfaces/renderkit/RenderKitUtils.java
+++ b/framework/src/main/java/org/richfaces/renderkit/RenderKitUtils.java
@@ -626,20 +626,86 @@ public final class RenderKitUtils {
         }
     }
 
-    public static String toScriptArgs(Object... objects) {
-        if (objects == null) {
-            return "";
+    /**
+     * <p>Returns arguments for script execution where null objects are stripped from the end of the argument list (they doesn't
+     * have to be part of JavaScript function execution).</p>
+     *
+     * <p>All other objects are converted to their JavaScript representation using {@link ScriptUtils#toScript(Object)}.</p>
+     *
+     * <p>This variant of the function is targeting zero arguments.</p>
+     *
+     * @see #toScriptArgs(Object)
+     * @see #toScriptArgs(Object, Object...)
+     */
+    public static String toScriptArgs() {
+        return "null";
+    }
+
+    /**
+     * <p>Returns arguments for script execution where null objects are stripped from the end of the argument list (they doesn't
+     * have to be part of JavaScript function execution).</p>
+     *
+     * <p>All other objects are converted to their JavaScript representation using {@link ScriptUtils#toScript(Object)}.</p>
+     *
+     * <p>This variant of the function is targeting no arguments.</p>
+     *
+     * @see #toScriptArgs()
+     * @see #toScriptArgs(Object, Object...)
+     */
+    public static String toScriptArgs(Object object) {
+        if (object == null) {
+            return "null";
         }
+
+        if (object.getClass().isArray()) {
+            Object[] array = (Object[]) object;
+            if (array.length == 0) {
+                return "[]";
+            }
+        }
+
+        return toScriptArgs_strippingNullObjectsFromEnd(object);
+    }
+
+    /**
+     * <p>Returns arguments for script execution where null objects are stripped from the end of the argument list (they doesn't
+     * have to be part of JavaScript function execution).</p>
+     *
+     * <p>All other objects are converted to their JavaScript representation using {@link ScriptUtils#toScript(Object)}.</p>
+     *
+     * <p>This variant of the function is targeting no arguments.</p>
+     *
+     * @see #toScriptArgs()
+     * @see #toScriptArgs(Object, Object...)
+     */
+    public static String toScriptArgs(Object object, Object... objects) {
+        if (objects == null) {
+            return toScriptArgs_strippingNullObjectsFromEnd(object);
+        }
+
+        Object[] args = new Object[objects.length + 1];
+        args[0] = object;
+        System.arraycopy(objects, 0, args, 1, objects.length);
+        return toScriptArgs_strippingNullObjectsFromEnd(args);
+    }
+
+    /**
+     * Returns arguments for script execution where null objects are stripped from the end of the argument list (they doesn't
+     * have to be part of JavaScript function execution).
+     *
+     * All other objects are converted to their JavaScript representation using {@link ScriptUtils#toScript(Object)}.
+     */
+    private static String toScriptArgs_strippingNullObjectsFromEnd(Object... objects) {
 
         int lastNonNullIdx = objects.length - 1;
         for (; 0 <= lastNonNullIdx; lastNonNullIdx--) {
-            if (!isEmpty(objects[lastNonNullIdx])) {
+            if (objects[lastNonNullIdx] != null) {
                 break;
             }
         }
 
         if (lastNonNullIdx < 0) {
-            return "";
+            return "null";
         }
 
         if (lastNonNullIdx == 0) {

--- a/framework/src/main/java/org/richfaces/ui/input/editor/editor.template.xml
+++ b/framework/src/main/java/org/richfaces/ui/input/editor/editor.template.xml
@@ -63,7 +63,7 @@
                 };
                 
                 (function() {
-                    var options = #{empty toScriptArgs(options) ? 'null' : toScriptArgs(options)};
+                    var options = #{toScriptArgs(options)};
                     var config = {
                     <c:choose>
                         <c:when test="#{configFacet != null and configFacet.isRendered()}">

--- a/framework/src/test/java/org/richfaces/renderkit/RenderKitUtilsTest.java
+++ b/framework/src/test/java/org/richfaces/renderkit/RenderKitUtilsTest.java
@@ -127,9 +127,9 @@ public class RenderKitUtilsTest {
 
     @Test
     public void testToScriptArgs() throws Exception {
-        assertEquals("", toScriptArgs());
-        assertEquals("", toScriptArgs((Object) null));
-        assertEquals("", toScriptArgs((Object[]) null));
+        assertEquals("null", toScriptArgs());
+        assertEquals("null", toScriptArgs((Object) null));
+        assertEquals("null", toScriptArgs((Object[]) null));
 
         assertEquals("\"test\"", toScriptArgs("test"));
         assertEquals("[5,8]", dehydrate(toScriptArgs(Arrays.asList(5, 8))));
@@ -138,13 +138,18 @@ public class RenderKitUtilsTest {
         assertEquals("\"test\"", toScriptArgs("test", null));
         assertEquals("null,\"test\"", toScriptArgs(null, "test"));
 
-        assertEquals("\"test\"", toScriptArgs("test", Collections.emptyList()));
+        assertEquals("[]", dehydrate(toScriptArgs(new Object[]{})));
+
+        assertEquals("[]", dehydrate(toScriptArgs(Collections.emptyList())));
+        assertEquals("\"test\",[] ", toScriptArgs("test", Collections.emptyList()));
         assertEquals("[],\"test\"", dehydrate(toScriptArgs(Collections.emptyList(), "test")));
 
-        assertEquals("\"test\"", toScriptArgs("test", Collections.emptyMap()));
+        assertEquals("{}", dehydrate(toScriptArgs(Collections.emptyMap())));
+        assertEquals("\"test\",{} ", toScriptArgs("test", Collections.emptyMap()));
         assertEquals("{},\"test\"", dehydrate(toScriptArgs(Collections.emptyMap(), "test")));
 
-        assertEquals("\"test\"", toScriptArgs("test", ""));
+
+        assertEquals("\"test\",\"\"", toScriptArgs("test", ""));
         assertEquals("\"\",\"test\"", dehydrate(toScriptArgs("", "test")));
 
         assertEquals("1,2,3", toScriptArgs(1, 2, 3, null));


### PR DESCRIPTION
I had to introduce several intermediate methods because otherwise we wouldn't be able to distinguish between following methods and support array arguments `[]` properly:

```
toScriptArgs(Object[]);
toScriptArgs(Object....);
```

`toScriptArgs()` doesn't make sense and we could remove it, since no one uses `#{toScriptArgs()}` with no arguments.

In the commit, I demonstrate how the code may be simplified now.
