### PR TITLE
RF-13475: Fixed Ehcache upgrade to 2.3.8

### DIFF
--- a/core/src/main/java/org/richfaces/cache/EhCacheCache.java
+++ b/core/src/main/java/org/richfaces/cache/EhCacheCache.java
@@ -64,7 +64,7 @@ public class EhCacheCache implements Cache {
     }
 
     public void put(Object key, Object value, Date expired) {
-        Integer ttl = null;
+        int ttl = 0;
 
         if (expired != null) {
             ttl = (int) (expired.getTime() - System.currentTimeMillis()) / 1000;


### PR DESCRIPTION
- constructor for Element no longer takes Integer for time to live parameter
