### PR TITLE
Pom Enhancement to allow easy MyEclipse Development

### DIFF
--- a/examples/components-demo/pom.xml
+++ b/examples/components-demo/pom.xml
@@ -33,7 +33,7 @@
 
     <artifactId>components-demo</artifactId>
     <groupId>org.richfaces.examples</groupId>
-    <name>RichFaces Example: Component </name>
+    <name>RichFaces Example - Component </name>
     <version>4.5.0-SNAPSHOT</version>
     <packaging>war</packaging>
 

--- a/examples/irc-client/pom.xml
+++ b/examples/irc-client/pom.xml
@@ -34,7 +34,7 @@
 
     <artifactId>irc-client</artifactId>
     <groupId>org.richfaces.examples</groupId>
-    <name>RichFaces Example: IRC Client</name>
+    <name>RichFaces Example - IRC Client</name>
     <packaging>war</packaging>
 
     <properties>

--- a/examples/jpa-demo/pom.xml
+++ b/examples/jpa-demo/pom.xml
@@ -34,7 +34,7 @@
     <groupId>org.richfaces.examples</groupId>
     <artifactId>jpa-demo</artifactId>
     <packaging>war</packaging>
-    <name>RichFaces Example: JPA Demo</name>
+    <name>RichFaces Example - JPA Demo</name>
 
     <properties>
         <version.richfaces>4.5.0-SNAPSHOT</version.richfaces>

--- a/examples/push-demo/pom.xml
+++ b/examples/push-demo/pom.xml
@@ -33,7 +33,7 @@
 
     <groupId>org.richfaces.examples</groupId>
     <artifactId>push-demo</artifactId>
-    <name>RichFaces Example: Push Demo</name>
+    <name>RichFaces Example - Push Demo</name>
     <packaging>war</packaging>
 
     <properties>

--- a/examples/standalone-js/pom.xml
+++ b/examples/standalone-js/pom.xml
@@ -33,7 +33,7 @@
 
     <artifactId>standalone-js</artifactId>
     <groupId>org.richfaces.examples</groupId>
-    <name>RichFaces Example: Component </name>
+    <name>RichFaces Example - Component </name>
     <version>4.5.0-SNAPSHOT</version>
     <packaging>war</packaging>
 


### PR DESCRIPTION
MyEclipse uses maven <name> for standard maven project import name.  The
use of colon is not allowed in this process.  The alternative to a
normal import is to know to switch to use the artifactId.  This may or
may not be preferred.  Therefore, this PR is to simply change the colon
to a space with a dash.  It still retains the original intent and makes
myEclipse developers life a little easier when contributing to
richfaces.
