### PR TITLE
Framework test clean-up, this will allow to execute them on Tomcat.

### DIFF
--- a/build/build-resources/src/main/java/org/richfaces/deployment/BaseDeployment.java
+++ b/build/build-resources/src/main/java/org/richfaces/deployment/BaseDeployment.java
@@ -92,28 +92,28 @@ public class BaseDeployment {
         this.facesConfig = Descriptors.create(WebFacesConfigDescriptor.class).version(FacesConfigVersionType._2_0);
 
         this.webXml = Descriptors.create(WebAppDescriptor.class)
-                .version("3.0")
-                .addNamespace("xmlns:web", "http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd")
-                .getOrCreateWelcomeFileList()
-                    .welcomeFile("faces/index.xhtml")
-                .up()
-                .getOrCreateContextParam()
-                    .paramName("javax.faces.PROJECT_STAGE")
-                    .paramValue("Development")
-                .up()
-                .getOrCreateServlet()
-                    .servletName(FacesServlet.class.getSimpleName())
-                    .servletClass(FacesServlet.class.getName())
-                    .loadOnStartup(1)
-                .up()
-                .getOrCreateServletMapping()
-                    .servletName(FacesServlet.class.getSimpleName())
-                    .urlPattern("*.jsf")
-                .up()
-                .getOrCreateServletMapping()
-                    .servletName(FacesServlet.class.getSimpleName())
-                    .urlPattern("/faces/*")
-                .up();
+            .version("3.0")
+            .addNamespace("xmlns:web", "http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd")
+            .getOrCreateWelcomeFileList()
+            .welcomeFile("faces/index.xhtml")
+            .up()
+            .getOrCreateContextParam()
+            .paramName("javax.faces.PROJECT_STAGE")
+            .paramValue("Development")
+            .up()
+            .getOrCreateServlet()
+            .servletName(FacesServlet.class.getSimpleName())
+            .servletClass(FacesServlet.class.getName())
+            .loadOnStartup(1)
+            .up()
+            .getOrCreateServletMapping()
+            .servletName(FacesServlet.class.getSimpleName())
+            .urlPattern("*.jsf")
+            .up()
+            .getOrCreateServletMapping()
+            .servletName(FacesServlet.class.getSimpleName())
+            .urlPattern("/faces/*")
+            .up();
 
         // Servlet container setup
         if (configuration.servletContainerSetup()) {
@@ -140,14 +140,14 @@ public class BaseDeployment {
     }
 
     /**
-     * Returns the final testable archive - packages all the resources which were configured separately
+     * Returns the final testable archive - packages all the resources which were configured separately, also adds empty
+     * beans.xml file
      */
     public WebArchive getFinalArchive() {
         WebArchive finalArchive = archive
-                .addAsWebInfResource(new StringAsset(facesConfig.exportAsString()), "faces-config.xml")
-                .addAsWebInfResource(new StringAsset(webXml.exportAsString()), "web.xml");
-
-
+            .addAsWebInfResource(new StringAsset(facesConfig.exportAsString()), "faces-config.xml")
+            .addAsWebInfResource(new StringAsset(webXml.exportAsString()), "web.xml")
+            .addAsWebInfResource(new File("src/test/resources/beans.xml"));
 
         // add library dependencies
         exportMavenDependenciesToArchive(finalArchive);
@@ -246,7 +246,6 @@ public class BaseDeployment {
         addMavenDependency(configuration.getJsfImplementation());
 
         addMavenDependency("org.jboss.weld.servlet:weld-servlet");
-        excludeMavenDependency("slf4j-api");
 
         addMavenDependency("org.jboss.el:jboss-el");
         excludeMavenDependency("el-api");
@@ -254,29 +253,28 @@ public class BaseDeployment {
         addMavenDependency("javax.annotation:jsr250-api:1.0");
         addMavenDependency("javax.servlet:jstl:1.2");
 
-
         webXml(new Function<WebAppDescriptor, WebAppDescriptor>() {
             public WebAppDescriptor apply(WebAppDescriptor webXml) {
 
                 // setup Weld Servlet
                 webXml
                     .createListener()
-                        .listenerClass("org.jboss.weld.environment.servlet.Listener");
+                    .listenerClass("org.jboss.weld.environment.servlet.Listener");
 
                 // setup ExpressionFactory of JBoss EL (supports unified EL)
                 switch (configuration.getJsfProvider()) {
                     case MOJARRA:
                         webXml
                             .getOrCreateContextParam()
-                                .paramName("com.sun.faces.expressionFactory")
-                                .paramValue("org.jboss.el.ExpressionFactoryImpl");
+                            .paramName("com.sun.faces.expressionFactory")
+                            .paramValue("org.jboss.el.ExpressionFactoryImpl");
                         break;
 
                     case MYFACES:
                         webXml
                             .getOrCreateContextParam()
-                                .paramName("org.apache.myfaces.EXPRESSION_FACTORY")
-                                .paramValue("org.jboss.el.ExpressionFactoryImpl");
+                            .paramName("org.apache.myfaces.EXPRESSION_FACTORY")
+                            .paramValue("org.jboss.el.ExpressionFactoryImpl");
                         break;
                 }
 
@@ -288,10 +286,12 @@ public class BaseDeployment {
     }
 
     /**
-     * <p>Add basic dependencies which RichFaces depends on.</p>
+     * <p>
+     * Add basic dependencies which RichFaces depends on.</p>
      *
-     * <p>This dependencies would be brought transitively by org.richfaces:richfaces:jar artifact, however
-     * in snapshot builds we don't rely on this dependency and we use target/richfaces.jar instead.</p>
+     * <p>
+     * This dependencies would be brought transitively by org.richfaces:richfaces:jar artifact, however in snapshot builds we
+     * don't rely on this dependency and we use target/richfaces.jar instead.</p>
      */
     private void addRequiredMavenDependencies() {
         addMavenDependency("com.google.guava:guava", "net.sourceforge.cssparser:cssparser");
@@ -309,11 +309,11 @@ public class BaseDeployment {
         if (missingDependency.matches("^[^:]+:[^:]+:[^:]+")) {
             // resolution of the artifact without a version specified
             dependencies = resolver.resolve(missingDependency).withClassPathResolution(false).withTransitivity()
-                    .as(JavaArchive.class);
+                .as(JavaArchive.class);
         } else {
             // resolution of the artifact without a version specified
             dependencies = resolver.loadPomFromFile("pom.xml").resolve(missingDependency)
-                    .withClassPathResolution(false).withTransitivity().as(JavaArchive.class);
+                .withClassPathResolution(false).withTransitivity().as(JavaArchive.class);
         }
 
         for (JavaArchive archive : dependencies) {

--- a/build/build-resources/src/test/resources/beans.xml
+++ b/build/build-resources/src/test/resources/beans.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    JBoss, Home of Professional Open Source
+    Copyright 2012, Red Hat Middleware LLC, and individual contributors
+    by the @authors tag. See the copyright.txt in the distribution for a
+    full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:weld="http://jboss.org/schema/weld/beans"
+       xsi:schemaLocation="
+          http://java.sun.com/xml/ns/javaee http://docs.jboss.org/cdi/beans_1_0.xsd
+         http://jboss.org/schema/weld/beans http://jboss.org/schema/weld/beans_1_1.xsd">
+
+    <weld:scan>
+        <weld:exclude pattern="^(.*)Test(.*)$" />
+    </weld:scan>
+</beans>

--- a/components/a4j/src/test/integration/org/richfaces/component/ajax/ITAjax.java
+++ b/components/a4j/src/test/integration/org/richfaces/component/ajax/ITAjax.java
@@ -35,7 +35,6 @@ public class ITAjax {
         A4JDeployment deployment = new A4JDeployment(ITAjax.class);
         deployment.archive().addClass(AjaxBean.class);
         addIndexPage(deployment);
-        deployment.archive().addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
 
         return deployment.getFinalArchive();
     }

--- a/components/a4j/src/test/integration/org/richfaces/component/ajax/ITJsFunction.java
+++ b/components/a4j/src/test/integration/org/richfaces/component/ajax/ITJsFunction.java
@@ -47,7 +47,6 @@ public class ITJsFunction {
         deployment.archive().addClass(AjaxBean.class);
         addIndexPage(deployment);
         addParamPage(deployment);
-        deployment.archive().addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
 
         return deployment.getFinalArchive();
     }

--- a/components/a4j/src/test/integration/org/richfaces/component/ajax/ITJsfAjaxScriptRendering.java
+++ b/components/a4j/src/test/integration/org/richfaces/component/ajax/ITJsfAjaxScriptRendering.java
@@ -68,7 +68,6 @@ public class ITJsfAjaxScriptRendering {
         A4JDeployment deployment = new A4JDeployment(ITJsfAjaxScriptRendering.class);
 
         addIndexPage(deployment);
-        deployment.archive().addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
 
         return deployment.getFinalArchive();
     }

--- a/components/a4j/src/test/integration/org/richfaces/component/ajax/IT_RF12512.java
+++ b/components/a4j/src/test/integration/org/richfaces/component/ajax/IT_RF12512.java
@@ -36,7 +36,6 @@ public class IT_RF12512 {
         deployment.archive().addClass(A4JRepeatBean.class);
         deployment.archive().addClass(AjaxBean.class);
         deployment.archive().addAsWebResource(new File("src/test/resources/org/richfaces/view/facelets/html/a4jrepeatMatrix.xhtml"));
-        deployment.archive().addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
         addIndexPage(deployment);
         return deployment.getFinalArchive();
     }

--- a/components/a4j/src/test/integration/org/richfaces/component/commandButton/ITCommandButtonImage.java
+++ b/components/a4j/src/test/integration/org/richfaces/component/commandButton/ITCommandButtonImage.java
@@ -50,8 +50,7 @@ public class ITCommandButtonImage {
     @Deployment(testable = false)
     public static WebArchive createDeployment() {
         A4JDeployment deployment = new A4JDeployment(ITCommandButtonImage.class);
-        deployment.archive().addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
-            .addAsWebResource(new File("src/test/resources/images/square.jpg"), "resources/square.jpg");
+        deployment.archive().addAsWebResource(new File("src/test/resources/images/square.jpg"), "resources/square.jpg");
         addIndexPage(deployment);
 
         return deployment.getFinalArchive();

--- a/components/a4j/src/test/integration/org/richfaces/component/region/AbstractRegionTest.java
+++ b/components/a4j/src/test/integration/org/richfaces/component/region/AbstractRegionTest.java
@@ -52,7 +52,6 @@ public abstract class AbstractRegionTest {
         RegionTestDeployment(Class<?> baseClass) {
             super(baseClass);
             this.archive().addClasses(RegionBean.class);
-            this.archive().addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
         }
     }
 

--- a/components/a4j/src/test/integration/org/richfaces/component/repeat/ITCollectionModel.java
+++ b/components/a4j/src/test/integration/org/richfaces/component/repeat/ITCollectionModel.java
@@ -59,8 +59,7 @@ public class ITCollectionModel {
         A4JDeployment deployment = new A4JDeployment(ITCollectionModel.class);
 
         deployment.archive()
-            .addClasses(CollectionModelBean.class)
-            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+            .addClasses(CollectionModelBean.class);
 
         addIndexPage(deployment);
 

--- a/components/a4j/src/test/integration/org/richfaces/component/repeat/ITNestedRepeat.java
+++ b/components/a4j/src/test/integration/org/richfaces/component/repeat/ITNestedRepeat.java
@@ -64,8 +64,7 @@ public class ITNestedRepeat {
 
         deployment.archive()
             .addClasses(NestedDataBean.class)
-            .addAsWebResource(ITNestedRepeat.class.getResource("NestedRepeatTest.xhtml"), "NestedRepeatTest.xhtml")
-            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+            .addAsWebResource(ITNestedRepeat.class.getResource("NestedRepeatTest.xhtml"), "NestedRepeatTest.xhtml");
 
         return deployment.getFinalArchive();
     }

--- a/components/rich/src/test/integration/org/richfaces/component/autocomplete/ITAutocompleteBehaviors.java
+++ b/components/rich/src/test/integration/org/richfaces/component/autocomplete/ITAutocompleteBehaviors.java
@@ -46,7 +46,7 @@ public class ITAutocompleteBehaviors {
     public static WebArchive createDeployment() {
         RichDeployment deployment = new RichDeployment(ITAutocompleteBehaviors.class);
 
-        deployment.archive().addClasses(AutocompleteBean.class).addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+        deployment.archive().addClasses(AutocompleteBean.class);
 
         addIndexPage(deployment);
 

--- a/components/rich/src/test/integration/org/richfaces/component/autocomplete/ITAutocompleteDestroy.java
+++ b/components/rich/src/test/integration/org/richfaces/component/autocomplete/ITAutocompleteDestroy.java
@@ -44,7 +44,7 @@ public class ITAutocompleteDestroy {
     public static WebArchive createDeployment() {
         RichDeployment deployment = new RichDeployment(ITAutocompleteDestroy.class);
 
-        deployment.archive().addClasses(AutocompleteBean.class).addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+        deployment.archive().addClasses(AutocompleteBean.class);
 
         addIndexPage(deployment);
 

--- a/components/rich/src/test/integration/org/richfaces/component/autocomplete/ITAutocompleteEvents.java
+++ b/components/rich/src/test/integration/org/richfaces/component/autocomplete/ITAutocompleteEvents.java
@@ -48,7 +48,7 @@ public class ITAutocompleteEvents {
     public static WebArchive createDeployment() {
         RichDeployment deployment = new RichDeployment(ITAutocompleteEvents.class);
 
-        deployment.archive().addClasses(AutocompleteBean.class).addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+        deployment.archive().addClasses(AutocompleteBean.class);
 
         addIndexPage(deployment);
 

--- a/components/rich/src/test/integration/org/richfaces/component/autocomplete/ITAutocompleteTokenizer.java
+++ b/components/rich/src/test/integration/org/richfaces/component/autocomplete/ITAutocompleteTokenizer.java
@@ -48,7 +48,7 @@ public class ITAutocompleteTokenizer {
     public static WebArchive createDeployment() {
         RichDeployment deployment = new RichDeployment(ITAutocompleteTokenizer.class);
 
-        deployment.archive().addClasses(AutocompleteBean.class).addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+        deployment.archive().addClasses(AutocompleteBean.class);
 
         addIndexPage(deployment);
 

--- a/components/rich/src/test/integration/org/richfaces/component/autocomplete/ITAutocompleteTokenizing.java
+++ b/components/rich/src/test/integration/org/richfaces/component/autocomplete/ITAutocompleteTokenizing.java
@@ -49,7 +49,7 @@ public class ITAutocompleteTokenizing {
     public static WebArchive createDeployment() {
         RichDeployment deployment = new RichDeployment(ITAutocompleteTokenizing.class);
 
-        deployment.archive().addClasses(AutocompleteBean.class).addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+        deployment.archive().addClasses(AutocompleteBean.class);
 
         addIndexPage(deployment);
 

--- a/components/rich/src/test/integration/org/richfaces/component/chart/ITChartBasic.java
+++ b/components/rich/src/test/integration/org/richfaces/component/chart/ITChartBasic.java
@@ -75,7 +75,7 @@ public class ITChartBasic {
     @Deployment(testable = false)
     public static WebArchive createDeployment() {
         RichDeployment deployment = new RichDeployment(ITChartBasic.class);
-        deployment.archive().addClasses(ChartBean.class).addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+        deployment.archive().addClasses(ChartBean.class);
         addIndexPage(deployment);
         return deployment.getFinalArchive();
     }

--- a/components/rich/src/test/integration/org/richfaces/component/fileUpload/ITFileUpload.java
+++ b/components/rich/src/test/integration/org/richfaces/component/fileUpload/ITFileUpload.java
@@ -52,7 +52,6 @@ public class ITFileUpload {
         RichDeployment deployment = new RichDeployment(ITFileUpload.class);
 
         deployment.archive().addClass(FileUploadBean.class);
-        deployment.archive().addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
 
         addIndexPage(deployment);
 

--- a/components/rich/src/test/integration/org/richfaces/component/focus/ITFocusDefaults.java
+++ b/components/rich/src/test/integration/org/richfaces/component/focus/ITFocusDefaults.java
@@ -53,7 +53,7 @@ public class ITFocusDefaults {
     public static WebArchive createDeployment() {
         RichDeployment deployment = new RichDeployment(ITFocusValidationAware.class);
 
-        deployment.archive().addClasses(ComponentBean.class).addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+        deployment.archive().addClasses(ComponentBean.class);
 
         addIndexPage(deployment);
 

--- a/components/rich/src/test/integration/org/richfaces/component/focus/ITFocusManager.java
+++ b/components/rich/src/test/integration/org/richfaces/component/focus/ITFocusManager.java
@@ -50,7 +50,6 @@ public class ITFocusManager {
         RichDeployment deployment = new RichDeployment(ITFocusManager.class);
 
         deployment.archive().addClasses(ComponentBean.class);
-        deployment.archive().addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
 
         addIndexPage(deployment);
         addViewFocusPage(deployment);

--- a/components/rich/src/test/integration/org/richfaces/component/focus/ITFocusSubmissionMethods.java
+++ b/components/rich/src/test/integration/org/richfaces/component/focus/ITFocusSubmissionMethods.java
@@ -60,7 +60,6 @@ public class ITFocusSubmissionMethods {
         RichDeployment deployment = new RichDeployment(ITFocusSubmissionMethods.class);
 
         deployment.archive().addClasses(ComponentBean.class);
-        deployment.archive().addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
 
         addIndexPage(deployment);
 

--- a/components/rich/src/test/integration/org/richfaces/component/focus/ITFocusValidationAware.java
+++ b/components/rich/src/test/integration/org/richfaces/component/focus/ITFocusValidationAware.java
@@ -67,7 +67,6 @@ public class ITFocusValidationAware {
         RichDeployment deployment = new RichDeployment(ITFocusValidationAware.class);
 
         deployment.archive().addClasses(ComponentBean.class);
-        deployment.archive().addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
 
         addIndexPage(deployment);
 

--- a/components/rich/src/test/integration/org/richfaces/component/menu/ITDropDownMenuItem.java
+++ b/components/rich/src/test/integration/org/richfaces/component/menu/ITDropDownMenuItem.java
@@ -74,8 +74,7 @@ public class ITDropDownMenuItem {
     public static WebArchive createDeployment() {
         RichDeployment deployment = new RichDeployment(ITDropDownMenuItem.class);
         deployment.archive()
-            .addClasses(DropDownMenuBean.class)
-            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+            .addClasses(DropDownMenuBean.class);
         addMenuItemPageWithMode(deployment, "menuItem_ajaxMode.xhtml", "ajax");
         addMenuItemPageWithMode(deployment, "menuItem_clientMode.xhtml", "client");
         addMenuItemPageWithMode(deployment, "menuItem_serverMode.xhtml", "server");

--- a/components/rich/src/test/integration/org/richfaces/component/select/ITSelectKeyboardSelection.java
+++ b/components/rich/src/test/integration/org/richfaces/component/select/ITSelectKeyboardSelection.java
@@ -47,7 +47,7 @@ public class ITSelectKeyboardSelection {
     public static WebArchive createDeployment() {
         RichDeployment deployment = new RichDeployment(ITSelectKeyboardSelection.class);
 
-        deployment.archive().addClasses(AutocompleteBean.class).addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+        deployment.archive().addClasses(AutocompleteBean.class);
 
         addIndexPage(deployment);
 

--- a/components/rich/src/test/integration/org/richfaces/component/select/ITSelectMouseSelection.java
+++ b/components/rich/src/test/integration/org/richfaces/component/select/ITSelectMouseSelection.java
@@ -41,7 +41,7 @@ public class ITSelectMouseSelection {
     public static WebArchive createDeployment() {
         RichDeployment deployment = new RichDeployment(ITSelectMouseSelection.class);
 
-        deployment.archive().addClasses(AutocompleteBean.class).addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+        deployment.archive().addClasses(AutocompleteBean.class);
 
         addIndexPage(deployment);
 

--- a/components/rich/src/test/integration/org/richfaces/component/select/ITSelectValidation.java
+++ b/components/rich/src/test/integration/org/richfaces/component/select/ITSelectValidation.java
@@ -44,7 +44,7 @@ public class ITSelectValidation {
     public static WebArchive createDeployment() {
         RichDeployment deployment = new RichDeployment(ITSelectValidation.class);
 
-        deployment.archive().addClasses(AutocompleteBean.class).addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+        deployment.archive().addClasses(AutocompleteBean.class);
 
         addIndexPage(deployment);
 

--- a/components/rich/src/test/integration/org/richfaces/component/toggle/panelMenu/ITPanelMenu.java
+++ b/components/rich/src/test/integration/org/richfaces/component/toggle/panelMenu/ITPanelMenu.java
@@ -65,8 +65,7 @@ public class ITPanelMenu {
     public static WebArchive createDeployment() {
         RichDeployment deployment = new RichDeployment(ITPanelMenu.class);
         deployment.archive()
-            .addClasses(PanelMenuBean.class)
-            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+            .addClasses(PanelMenuBean.class);
         addDisabledMenuItemPage(deployment);
         addDisabledMenuGroupPage(deployment);
         addDisabledMenuGroupPageClient(deployment);

--- a/components/rich/src/test/integration/org/richfaces/component/validation/ITValidatorMessageWithLabel.java
+++ b/components/rich/src/test/integration/org/richfaces/component/validation/ITValidatorMessageWithLabel.java
@@ -69,7 +69,6 @@ public class ITValidatorMessageWithLabel {
 
         addIndexPage(deployment);
 
-        deployment.archive().addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
         deployment.archive().addAsResource(messageBundleResource);
 
         deployment.facesConfig(new Function<WebFacesConfigDescriptor, WebFacesConfigDescriptor>() {

--- a/components/rich/src/test/integration/org/richfaces/integration/RichDeployment.java
+++ b/components/rich/src/test/integration/org/richfaces/integration/RichDeployment.java
@@ -1,10 +1,9 @@
 package org.richfaces.integration;
 
-import java.io.File;
-
 import org.jboss.shrinkwrap.api.Filters;
 import org.jboss.shrinkwrap.api.GenericArchive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.importer.ExplodedImporter;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.richfaces.arquillian.configuration.FundamentalTestConfiguration;
@@ -28,8 +27,8 @@ public class RichDeployment extends BaseDeployment {
             addCurrentProjectClasses();
 
             this.addMavenDependency(
-                    "org.richfaces:richfaces-core",
-                    "org.richfaces:richfaces-a4j");
+                "org.richfaces:richfaces-core",
+                "org.richfaces:richfaces-a4j");
 
         } else {
             String version = configuration.getRichFacesVersion();
@@ -39,15 +38,13 @@ public class RichDeployment extends BaseDeployment {
                 "org.richfaces:richfaces:" + version);
         }
 
-        archive().addAsWebInfResource(new File("src/test/resources/beans.xml"));
-
     }
 
     private void addCurrentProjectClasses() {
         JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "richfaces.jar");
         jar.merge(ShrinkWrap.create(GenericArchive.class).as(ExplodedImporter.class)
-                .importDirectory("target/classes/").as(GenericArchive.class),
-                "/", Filters.includeAll());
+            .importDirectory("target/classes/").as(GenericArchive.class),
+            "/", Filters.includeAll());
         archive().addAsLibrary(jar);
     }
 

--- a/components/rich/src/test/integration/org/richfaces/integration/skin/ITBlueSkySkin.java
+++ b/components/rich/src/test/integration/org/richfaces/integration/skin/ITBlueSkySkin.java
@@ -83,7 +83,6 @@ public class ITBlueSkySkin extends AbstractSkinTestBase {
         });
 
         addIndexPage(deployment);
-        deployment.archive().addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
 
         return deployment.getFinalArchive();
     }

--- a/components/rich/src/test/integration/org/richfaces/integration/skin/ITPlainSkin.java
+++ b/components/rich/src/test/integration/org/richfaces/integration/skin/ITPlainSkin.java
@@ -81,7 +81,6 @@ public class ITPlainSkin {
 
 
         addIndexPage(deployment);
-        deployment.archive().addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
 
         return deployment.getFinalArchive();
     }

--- a/components/rich/src/test/integration/org/richfaces/integration/skin/ITSkin.java
+++ b/components/rich/src/test/integration/org/richfaces/integration/skin/ITSkin.java
@@ -33,7 +33,6 @@ import org.jboss.arquillian.drone.api.annotation.Drone;
 import org.jboss.arquillian.graphene.Graphene;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.webapp30.WebAppDescriptor;
 import org.junit.Assert;
@@ -42,10 +41,10 @@ import org.junit.runner.RunWith;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
+import org.richfaces.integration.RichDeployment;
 import org.richfaces.shrinkwrap.descriptor.FaceletAsset;
 
 import com.google.common.base.Function;
-import org.richfaces.integration.RichDeployment;
 
 @RunAsClient
 @RunWith(Arquillian.class)
@@ -75,22 +74,22 @@ public class ITSkin extends AbstractSkinTestBase {
     @Deployment(testable = false)
     public static WebArchive createDeployment() {
         RichDeployment deployment = new RichDeployment(ITSkin.class);
-        deployment.archive().addClass(SkinTestBean.class);
+        deployment.archive().addClass(SkinBean.class);
         deployment.archive().addAsResource("bindedtest.skin.properties");
         deployment.webXml(new Function<WebAppDescriptor, WebAppDescriptor>() {
             public WebAppDescriptor apply(WebAppDescriptor input) {
 
                 input.getOrCreateContextParam()
                     .paramName("org.richfaces.skin")
-                    .paramValue("#{skinTestBean.skin}");
+                    .paramValue("#{skinBean.skin}");
 
                 return input;
-            };
+            }
+        ;
         });
 
 
         addIndexPage(deployment);
-        deployment.archive().addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
 
         return deployment.getFinalArchive();
     }
@@ -118,7 +117,6 @@ public class ITSkin extends AbstractSkinTestBase {
         assertEquals("eAFjZGBkZOBm!P-f8f-n70Bi37UfDEwAUQgJhA__", parameters.get("db"));
         assertEquals("org.richfaces.images", parameters.get("ln"));
 
-
         Graphene.guardHttp(buttonSkin2).click();
         url = getBackgroundUrl(buttonSkin1);
         parameters = parseQueryParameters(url);
@@ -135,9 +133,9 @@ public class ITSkin extends AbstractSkinTestBase {
         p.form("<rich:panel id='panel' header='Header Text'>Some content ");
         p.form("    <h:inputText id='input' /> ");
         p.form("</rich:panel> ");
-        p.form("<h:commandButton id='buttonSkin1' actionListener='#{skinTestBean.setSkin(\"blueSky\")}' value = 'Select skin 1' /> ");
-        p.form("<h:commandButton id='buttonSkin2' actionListener='#{skinTestBean.setSkin(\"ruby\")}' value = 'Select skin 2' /> ");
-        p.form("<h:commandButton id='buttonSkin3' actionListener='#{skinTestBean.setSkin(\"plain\")}' value = 'Select skin 3' /> ");
+        p.form("<h:commandButton id='buttonSkin1' actionListener='#{skinBean.setSkin(\"blueSky\")}' value = 'Select skin 1' /> ");
+        p.form("<h:commandButton id='buttonSkin2' actionListener='#{skinBean.setSkin(\"ruby\")}' value = 'Select skin 2' /> ");
+        p.form("<h:commandButton id='buttonSkin3' actionListener='#{skinBean.setSkin(\"plain\")}' value = 'Select skin 3' /> ");
         deployment.archive().addAsWebResource(p, "index.xhtml");
     }
 }

--- a/components/rich/src/test/integration/org/richfaces/integration/skin/SkinBean.java
+++ b/components/rich/src/test/integration/org/richfaces/integration/skin/SkinBean.java
@@ -19,16 +19,17 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-
 package org.richfaces.integration.skin;
+
+import java.io.Serializable;
 
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Named;
-import java.io.Serializable;
 
 @Named
 @SessionScoped
-public class SkinTestBean implements Serializable {
+public class SkinBean implements Serializable {
+
     private static final long serialVersionUID = 1L;
     private String skin = "DEFAULT";
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -162,13 +162,6 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- tests -->
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-validator</artifactId>
-            <scope>test</scope>
-        </dependency>
-
         <!-- Resource Optimizer -->
         <dependency>
             <groupId>org.reflections</groupId>


### PR DESCRIPTION
Removed unnecessary dependency for hibernate from richfaces/core/pom.xml.
Build resources: removed dependency exclusion from BaseDeployment.
Added beans.xml to build-resources and modified BaseDeployment to make use of it. This will create a non-empty beans.xml file for FW tests and should allow resource tests to execute on Tomcat.
Changed ITSkin test and the name of the related backing bean to avoid problems with weld bean scan process

@michpetrov please review this PR and merge it if its OK.